### PR TITLE
Minor logic update + fix for Charge Badge

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "TTYD Key Item Tracker",
     "game_name": "TTYD",
-    "package_version": "0.10.0",
+    "package_version": "0.10.1",
     "package_uid": "ttyd_ap",
     "author": "ZobeePlays & earthor1",
     "variants": {

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -105,3 +105,6 @@ function palaceright()
 function palace()
 	return (ttyd()) and (((stars(0)) and has("0ChapterClears")) or ((stars(1)) and has("1ChapterClears")) or ((stars(2)) and has("2ChapterClears")) or ((stars(3)) and has("3ChapterClears")) or ((stars(4)) and has("4ChapterClears")) or ((stars(5)) and has("5ChapterClears")) or ((stars(6)) and has("6ChapterClears")) or ((stars(7)) and has("7ChapterClears")))
 	end		
+function punikey()
+	return has("PuniOrb") and (has("RedKey") or has("BlueKey"))
+	end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -105,6 +105,6 @@ function palaceright()
 function palace()
 	return (ttyd()) and (((stars(0)) and has("0ChapterClears")) or ((stars(1)) and has("1ChapterClears")) or ((stars(2)) and has("2ChapterClears")) or ((stars(3)) and has("3ChapterClears")) or ((stars(4)) and has("4ChapterClears")) or ((stars(5)) and has("5ChapterClears")) or ((stars(6)) and has("6ChapterClears")) or ((stars(7)) and has("7ChapterClears")))
 	end		
-function punikey()
+function tenpunis()
 	return has("PuniOrb") and (has("RedKey") or has("BlueKey"))
 	end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -108,3 +108,6 @@ function palace()
 function tenpunis()
 	return has("PuniOrb") and (has("RedKey") or has("BlueKey"))
 	end
+function hundredpunis()
+	return has("PuniOrb") and has("RedKey") and has("BlueKey")
+	end

--- a/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
+++ b/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
@@ -1208,13 +1208,13 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,BlueKey"],
+                        "access_rules": ["$hundredpunis"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree 100-Puni Pedestal - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,BlueKey"],
+                        "access_rules": ["$hundredpunis"],
                         "item_count": 1
                     },
                     {
@@ -1222,19 +1222,19 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,BlueKey"],
+                        "access_rules": ["$hundredpunis"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Lower Duplex - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,SuperBoots,BlueKey"],
+                        "access_rules": ["$hundredpunis,SuperBoots"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Pool Room - Dizzy Dial",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops"],
                         "item_count": 1
                     },
                     {
@@ -1242,7 +1242,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey","RedKey,PuniOrb,UltraBoots,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops","$hundredpunis,UltraBoots"],
                         "item_count": 1
                     },
                     {
@@ -1250,13 +1250,13 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Elevator Pedestal - Mushroom",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops"],
                         "item_count": 1
                     },
                     {
@@ -1264,7 +1264,7 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops"],
                         "item_count": 1
                     },
                     {
@@ -1272,7 +1272,7 @@
                         "chest_unopened_img": "/images/items/EmeraldStarHD2.png",
                         "chest_opened_img": "/images/items/ClosedStar.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
+                        "access_rules": ["$hundredpunis,Koops"],
                         "item_count": 1
                     },
                     {

--- a/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
+++ b/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
@@ -3336,7 +3336,7 @@
                     {
                         "name": "Keelhaul Key Jungle Bridge - Ice Power",
                         "visibility_rules": [""],
-                        "access_rules": ["[$yoshi],[PaperCurse]"],
+                        "access_rules": ["$yoshi,[PaperCurse]"],
                         "item_count": 1
                     },
                     {

--- a/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
+++ b/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
@@ -1134,13 +1134,13 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb","BlueKey,PuniOrb"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Bubble Room - Thunder Rage",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb","BlueKey,PuniOrb"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
@@ -1148,13 +1148,13 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,PlaneCurse","BlueKey,PuniOrb,PlaneCurse"],
+                        "access_rules": ["$punikey,PlaneCurse"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Zigzag Room - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb","BlueKey,PuniOrb"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
@@ -1162,7 +1162,7 @@
                         "chest_unopened_img": "/images/items/RBlock.png",
                         "chest_opened_img": "/images/items/RBlockOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb","BlueKey,PuniOrb"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
@@ -1170,7 +1170,7 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb","BlueKey,PuniOrb"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
@@ -1178,13 +1178,13 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie","BlueKey,PuniOrb,Flurrie"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Blue Key Room - Charge",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,SuperBoots","BlueKey,PuniOrb,Flurrie,SuperBoots"],
+                        "access_rules": ["$punikey,SuperBoots,Koops","$punikey,SuperBoots,$yoshi"],
                         "item_count": 1
                     },
                     {
@@ -1192,7 +1192,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,SuperBoots","BlueKey,PuniOrb,Flurrie,SuperBoots"],
+                        "access_rules": ["$punikey,SuperBoots"],
                         "item_count": 1
                     },
                     {
@@ -1200,7 +1200,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie","BlueKey,PuniOrb,Flurrie"],
+                        "access_rules": ["$punikey"],
                         "item_count": 1
                     },
                     {
@@ -1228,13 +1228,13 @@
                     {
                         "name": "Great Tree Lower Duplex - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,SuperBoots,BlueKey"],
+                        "access_rules": ["RedKey,PuniOrb,SuperBoots,BlueKey"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Pool Room - Dizzy Dial",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,Koops,BlueKey"],
+                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
                         "item_count": 1
                     },
                     {
@@ -1242,7 +1242,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,Koops,BlueKey","RedKey,PuniOrb,Flurrie,UltraBoots,BlueKey"],
+                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey","RedKey,PuniOrb,UltraBoots,BlueKey"],
                         "item_count": 1
                     },
                     {
@@ -1250,7 +1250,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,Koops,BlueKey"],
+                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
                         "item_count": 1
                     },
                     {
@@ -1272,7 +1272,7 @@
                         "chest_unopened_img": "/images/items/EmeraldStarHD2.png",
                         "chest_opened_img": "/images/items/ClosedStar.png",
                         "visibility_rules": [""],
-                        "access_rules": ["RedKey,PuniOrb,Flurrie,Koops,BlueKey"],
+                        "access_rules": ["RedKey,PuniOrb,Koops,BlueKey"],
                         "item_count": 1
                     },
                     {
@@ -1304,7 +1304,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch2"],
                 "access_rules": [
-                    "Flurrie,$bogglywoods,RedKey,PuniOrb","Flurrie,$bogglywoods,BlueKey,PuniOrb"
+                    "Flurrie,$bogglywoods,$punikey"
                 ],
                 "sections": [
                     {

--- a/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
+++ b/var_SwitchRemakeNoOutlinesWithMap/locations/Overworld.json
@@ -1134,13 +1134,13 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Bubble Room - Thunder Rage",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
@@ -1148,13 +1148,13 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey,PlaneCurse"],
+                        "access_rules": ["$tenpunis,PlaneCurse"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Zigzag Room - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
@@ -1162,7 +1162,7 @@
                         "chest_unopened_img": "/images/items/RBlock.png",
                         "chest_opened_img": "/images/items/RBlockOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
@@ -1170,7 +1170,7 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
@@ -1178,13 +1178,13 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Blue Key Room - Charge",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey,SuperBoots,Koops","$punikey,SuperBoots,$yoshi"],
+                        "access_rules": ["$tenpunis,SuperBoots,Koops","$tenpunis,SuperBoots,$yoshi"],
                         "item_count": 1
                     },
                     {
@@ -1192,7 +1192,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey,SuperBoots"],
+                        "access_rules": ["$tenpunis,SuperBoots"],
                         "item_count": 1
                     },
                     {
@@ -1200,7 +1200,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$punikey"],
+                        "access_rules": ["$tenpunis"],
                         "item_count": 1
                     },
                     {
@@ -1304,7 +1304,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch2"],
                 "access_rules": [
-                    "Flurrie,$bogglywoods,$punikey"
+                    "Flurrie,$bogglywoods,$tenpunis"
                 ],
                 "sections": [
                     {


### PR DESCRIPTION
- Added new function to logic.lua to check for Puni Orb + Red Key OR Blue Key
- Removed Flurrie from item level access rules as they were already called out in the section
- Added missing Koops/Yoshi requirement for "Great Tree Blue Key Room - Charge" check

Incremented the manifest in my second commit since I forgot to do that in my first one ._.