### PR TITLE
Minor fixes for Pit Items (slot data)

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -842,9 +842,22 @@
     },
     {
         "name": "Is The Pit of 100 Trials Included?",
-        "type": "toggle",
-        "img": "images/items/BigChest.png",
-        "codes": "Pit_Items"
+        "type": "progressive",
+        "allow_disabled": false,
+        "stages": [
+            {
+                "name": "No Pit Included",
+                "img": "images/items/BigChestDim.png",
+                "inherit_codes": false,
+                "codes": "NoPit, Pit_Items"
+            },
+            {
+                "name": "Pit is Included",
+                "img": "images/items/BigChest.png",
+                "inherit_codes": false,
+                "codes": "YesPit, Pit_Items"
+            }
+        ]
     },
     {
         "name": "ZobeePlays on Discord!",

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -480,7 +480,7 @@
                 "chest_unopened_img": "/images/items/BigChest.png",
                 "chest_opened_img": "/images/items/BigChestOpen.png",
                 "overlay_background": "#000000",
-                "visibility_rules": ["Pit_Items"],
+                "visibility_rules": ["YesPit"],
                 "access_rules": [
                     "$pit"
                 ],

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -3408,7 +3408,7 @@
                     {
                         "name": "Keelhaul Key Town - Chuckola Cola",
                         "visibility_rules": [""],
-                        "access_rules": ["$yoshi,Coconut,OldLetter,$tube"],
+                        "access_rules": ["$yoshi,Coconut"],
                         "item_count": 1
                     },
                     {
@@ -3574,7 +3574,7 @@
                     {
                         "name": "Keelhaul Key Grotto Entrance - Wedding Ring",
                         "visibility_rules": [""],
-                        "access_rules": ["SapphireStar"],
+                        "access_rules": ["$yoshi"],
                         "item_count": 1
                     }
 		],

--- a/locations/Poshley_Heights.json
+++ b/locations/Poshley_Heights.json
@@ -47,6 +47,10 @@
             {
                 "sections": [{"ref": "Magical Map/Poshley Heights/Poshley Heights Downtown - Star Piece"}],
                 "map_locations": [{"map": "Poshley Heights", "x": 1503, "y": 1770}]
+            },
+            {
+                "sections": [{"ref": "Magical Map/Excess Express/Excess Express Front Passenger Car - 30 Coins"}],
+                "map_locations": [{"map": "Poshley Heights", "x": 1254, "y": 1686}]
             }
         ]
     }

--- a/locations/Sewers.json
+++ b/locations/Sewers.json
@@ -239,5 +239,37 @@
                 "map_locations": [{"map": "Sewers", "x": 1494, "y": 832}]
             }
         ]
+    },
+    {
+        "name": "Pit of 100 Trials",
+        "children": [
+            {
+                "sections": [{"name": "Pit of 100 Trials Floor 10 - Sleepy Stomp", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 10 - Sleepy Stomp"},
+                             {"name": "Pit of 100 Trials Floor 20 - Fire Drive", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 20 - Fire Drive"},
+                             {"name": "Pit of 100 Trials Floor 30 - Zap Tap", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 30 - Zap Tap"},
+                             {"name": "Pit of 100 Trials Floor 40 - Pity Flower", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 40 - Pity Flower"},
+                             {"name": "Pit of 100 Trials Floor 50 - Strange Sack", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 50 - Strange Sack"},
+                             {"name": "Pit of 100 Trials Floor 60 - Double Dip", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 60 - Double Dip"},
+                             {"name": "Pit of 100 Trials Floor 70 - Double Dip P", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 70 - Double Dip P"},
+                             {"name": "Pit of 100 Trials Floor 80 - Bump Attack", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 80 - Bump Attack"},
+                             {"name": "Pit of 100 Trials Floor 90 - Lucky Day", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 90 - Lucky Day"},
+                             {"name": "Pit of 100 Trials Floor 100 - Return Postage", "ref": "Magical Map/Pit of 100 Trials/Pit of 100 Trials Floor 100 - Return Postage"}],
+                "map_locations": [{"map": "Sewers", "x": 1533, "y": 1989}]
+            }
+        ]
+    },
+    {
+        "name": "Pit of 100 Trials Charlieton",
+        "children": [
+            {
+                "sections": [{"name": "Pit of 100 Trials Charlieton - Fire Flower", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Fire Flower"},
+                             {"name": "Pit of 100 Trials Charlieton - Honey Syrup", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Honey Syrup"},
+                             {"name": "Pit of 100 Trials Charlieton - Maple Syrup", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Maple Syrup"},
+                             {"name": "Pit of 100 Trials Charlieton - Mushroom", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Mushroom"},
+                             {"name": "Pit of 100 Trials Charlieton - Super Shroom", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Super Shroom"},
+                             {"name": "Pit of 100 Trials Charlieton - Thunder Rage", "ref": "Magical Map/Pit of 100 Trials Charlieton/Pit of 100 Trials Charlieton - Thunder Rage"}],
+                "map_locations": [{"map": "Sewers", "x": 1533, "y": 1854}]
+            }
+        ]
     }
 ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "TTYD Key Item Tracker",
     "game_name": "TTYD",
-    "package_version": "1.0.0",
+    "package_version": "1.0.1",
     "package_uid": "ttyd_ap",
     "author": "ZobeePlays, earthor1, & PillarAngel",
     "versions_url": "https://raw.githubusercontent.com/ZobeePlays/TTYD-Randomizer-AP-Tracker/refs/heads/main/versions.json",

--- a/var_SwitchRemakeNoOutlinesWithMap/layouts/items.json
+++ b/var_SwitchRemakeNoOutlinesWithMap/layouts/items.json
@@ -1,0 +1,131 @@
+{
+    "shared_item_grid_horizontal": {
+        "type": "array",
+        "orientation": "horizontal",
+        "margin": "0,0",
+        "content": [
+            {
+                "type": "array",
+                "orientation": "horizontal",
+                "margin": "0,0",
+                "content": [
+                    {
+                        "type": "itemgrid",
+                        "item_margin": "2, 2",
+                        "h_alignment": "left",
+                        "item_h_alignment": "center",
+                        "item_v_alignment": "center",
+                        "item_height": 36,
+                        "item_width": 36,
+                        "rows": [
+                            [
+                                "DiamondStar",
+                                "EmeraldStar",
+                                "GoldStar",
+                                "RubyStar",
+                                "SapphireStar",
+                                "GarnetStar",
+                                "CrystalStar"
+                            ],
+                            [
+                                "Goombella",
+                                "Koops",
+                                "Flurrie",
+                                "Yoshi",
+                                "Vivian",
+                                "Bobbery",
+                                "Mowz"
+                            ],
+                            [
+                                "Bootss",
+                                "Hammers",
+                                "StrangeSack",
+                                "PlaneCurse",
+                                "PaperCurse",
+                                "TubeCurse",
+                                "BoatCurse"
+                            ],
+                            [
+                                "ContactLens",
+                                "BlimpTicket",
+                                "OldLetter",
+                                "TrainTicket",
+                                "GoldbobGuide",
+                                "StarPiece",
+                                "ShineSprite"
+                            ],
+                            [
+                                "f"
+                            ],
+                            [
+                                "BlackKey1",
+                                "SunStone",
+                                "MoonStone",
+                                "CastleKey",
+                                "BlackKey2"
+                            ],
+                            [
+                                "Necklace",
+                                "RedKey",
+                                "PuniOrb",
+                                "BlueKey",
+                                "f",
+                                "StorageKey1",
+                                "StorageKey2"
+                            ],
+                            [
+                                "ShopKey",
+                                "BlackKey3",
+                                "SteepleKey1",
+                                "Superbombomb",
+                                "TheLetterP"
+                            ],
+                            [
+                                "ChuckolaCola",
+                                "Coconut",
+                                "SkullGem",
+                                "GrottoKey",
+                                "BlackKey4",
+                                "GateHandle",
+                                "WeddingRing"
+                            ],
+                            [
+                                "Autograph",
+                                "RaggedDiary",
+                                "Blanket",
+                                "VitalPaper",
+                                "StationKey1",
+                                "StationKey2",
+                                "ElevatorKey"
+                            ],
+                            [
+                                "GalleyPot",
+                                "Briefcase",
+                                "GoldRing",
+                                "ShellEarrings"
+                            ],
+                            [
+                                "CardKey1",
+                                "CardKey2",
+                                "CardKey3",
+                                "CardKey4",
+                                "ElevatorKey1",
+                                "ElevatorKey2",
+                                "Cog"
+                            ],
+                            [
+                                "PalaceKey",
+                                "StarKey",
+                                "PalaceKey(RiddleTower)",
+                                "F",
+                                "F",
+                                "Cookbook",
+                                "UpArrow"
+                            ]
+						]
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
- Swapped root level items.json from toggle to progressive so it could import slot data appropriately.
- Added Pit of 100 trials and Pit of 100 trials - Charlieton to sewers.json map
- Re-added back layout/items.json to variant level as there was height/width overrides there