### PR TITLE
Various minor bugfixes

### DIFF
--- a/locations/Fhar_Outpost.json
+++ b/locations/Fhar_Outpost.json
@@ -15,7 +15,7 @@
                 "map_locations": [{"map": "Fahr Outpost", "x": 810, "y": 499}]
             },
             {
-                "sections": [{"ref": "Magical Map/Fahr Outpost/Fahr Outpost West Enemy Room - Shine Sprite"}],
+                "sections": [{"ref": "Magical Map/Fahr Outpost/Fahr Outpost West Enemy Room - Star Piece"}],
                 "map_locations": [{"map": "Fahr Outpost", "x": 1014, "y": 683}]
             },
             {

--- a/locations/Glitz_Pit.json
+++ b/locations/Glitz_Pit.json
@@ -43,6 +43,10 @@
                 "map_locations": [{"map": "The Glitz Pit", "x": 417, "y": 531}]
             },
             {
+                "sections": [{"ref": "Magical Map/Glitzpit/Glitzville Minor-League Room - Yoshi"}],
+                "map_locations": [{"map": "The Glitz Pit", "x": 834, "y": 759}]
+            },
+            {
                 "sections": [{"ref": "Magical Map/Glitzpit/Glitzville Major-League Room - Champ's Belt"}],
                 "map_locations": [{"map": "The Glitz Pit", "x": 1419, "y": 372}]
             },

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -2830,7 +2830,7 @@
                     {
                         "name": "Hooktail's Castle Life Shroom Room - Life Shroom",
                         "visibility_rules": [""],
-                        "access_rules": ["$htcastle,PaperCurse,Koops,CastleKey2","$htcastle,CastleKey2,[Koops],$yoshi,Bobbery"],
+                        "access_rules": ["$htcastle,Koops,CastleKey2","$htcastle,CastleKey2,[Koops],$yoshi,Bobbery"],
                         "item_count": 1
                     },
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -3756,7 +3756,7 @@
                     {
                         "name": "Pirate's Grotto Chest Boat - Black Key 4",
                         "visibility_rules": [""],
-                        "access_rules": ["$yoshi,GrottoKey,$tube"],
+                        "access_rules": ["$yoshi,GrottoKey,$tube","$yoshi,GrottoKey,Vivian"],
                         "item_count": 1
                     },
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -3470,7 +3470,7 @@
                     {
                         "name": "Keelhaul Key Jungle Winding Climb - Coin 1",
                         "visibility_rules": [""],
-                        "access_rules": ["$yoshi"],
+                        "access_rules": [""],
                         "item_count": 1
                     },
                     {
@@ -4030,7 +4030,7 @@
                     {
                         "name": "Riverside Station Ultra Boots Room - Elevator Key",
                         "visibility_rules": [""],
-                        "access_rules": ["UltraBoots,Flurrie,StationKey1,StationKey2,$tube"],
+                        "access_rules": ["UltraBoots,Flurrie,StationKey1,StationKey2,$tube","Flurrie,StationKey1,StationKey2,$tube,{}"],
                         "item_count": 1
                     }
 		],

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -2838,7 +2838,7 @@
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$htcastle,PaperCurse,Koops,CastleKey3,PaperCurse","$htcastle,PaperCurse,CastleKey3,[Koops],$yoshi,Bobbery"],
+                        "access_rules": ["$htcastle,PaperCurse,Koops,CastleKey3","$htcastle,PaperCurse,CastleKey3,[Koops],$yoshi,Bobbery","$htcastle,Koops,CastleKey3,{}","$htcastle,CastleKey3,[Koops],$yoshi,Bobbery,{}"],
                         "item_count": 1
                     },
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -2020,7 +2020,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch3"],
                 "access_rules": [
-                    "$westside,BlimpTicket","$HRGlvl1,[BlimpTicket]"
+                    "$westside,BlimpTicket","[$westside],BlimpTicket,$HRGlvl1"
                 ],
                 "sections": [
                     {
@@ -2126,7 +2126,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch3"],
                 "access_rules": [
-                    "$westside,BlimpTicket","$HRGlvl1,[BlimpTicket]"
+                    "$westside,BlimpTicket","[$westside],BlimpTicket,$HRGlvl1"
                 ],
                 "sections": [
                     {
@@ -2200,7 +2200,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch3"],
                 "access_rules": [
-                    "$westside,BlimpTicket","$HRGlvl1,[BlimpTicket]"
+                    "$westside,BlimpTicket","[$westside],BlimpTicket,$HRGlvl1"
                 ],
                 "sections": [
                     {
@@ -4056,7 +4056,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch6"],
                 "access_rules": [
-                    "$westside,TrainTicket","[TrainTicket],$HRGlvl1"
+                    "$westside,TrainTicket","[$westside],TrainTicket,$HRGlvl1"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -597,7 +597,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["PaperCurse,[$yoshi]"],
+                        "access_rules": ["[PaperCurse],$yoshi","PaperCurse,[$yoshi]"],
                         "item_count": 1
                     },
                     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "TTYD Key Item Tracker",
     "game_name": "TTYD",
-    "package_version": "1.0.2",
+    "package_version": "1.0.3",
     "package_uid": "ttyd_ap",
     "author": "ZobeePlays, earthor1, & PillarAngel",
     "versions_url": "https://raw.githubusercontent.com/ZobeePlays/TTYD-Randomizer-AP-Tracker/refs/heads/main/versions.json",


### PR DESCRIPTION
- Corrected Star Piece in Fahr Outpost West Enemy Room being another Shine Sprite
- Added Yoshi check in Glitz Pit (was missing)
- Added OoL access to Rogueport Eastside - Shine Sprite 2 (lock jump + paper)
- Star Piece in Hooktail Castle Plane Rafters Room scoutable without paper
- Fixed Keelhaul Key Jungle Winding Climb - Coin 1 inappropriately checking for Yoshi
- Fixed scenario where Pirate's Grotto Chest Boat - Black Key 4 wasn't considered collectable with Vivian
- Made Riverside Station Elevator Key scoutable when you don't have Ultra Boots
- Fix for HRG showing Glitzville/Excess Express showing available but OoL from start
- Removing Paper Curse requirement for Life Shroom check in Hooktail's Castle