### PR TITLE
Update access rules and logic for overworld locations

### DIFF
--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -767,7 +767,7 @@
                     {
                         "name": "Rogueport Westside - Train Ticket",
                         "visibility_rules": [""],
-                        "access_rules": ["SapphireStar,WeddingRing"],
+                        "access_rules": ["WeddingRing"],
                         "item_count": 1
                     },
                     {
@@ -3554,7 +3554,7 @@
                     {
                         "name": "Keelhaul Key Grotto Entrance - Skull Gem",
                         "visibility_rules": [""],
-                        "access_rules": ["Coconut,$yoshi,ChuckolaCola"],
+                        "access_rules": ["Coconut,$yoshi"],
                         "item_count": 1
                     },
                     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "TTYD Key Item Tracker",
     "game_name": "TTYD",
-    "package_version": "1.0.4",
+    "package_version": "1.0.5",
     "package_uid": "ttyd_ap",
     "author": "ZobeePlays, earthor1, & PillarAngel",
     "versions_url": "https://raw.githubusercontent.com/ZobeePlays/TTYD-Randomizer-AP-Tracker/refs/heads/main/versions.json",

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -35,11 +35,11 @@ function pit()
 	end
 
 function sewerwest()
-	return (has("ContactLens") and has("PaperCurse")) or (has("UltraHammer") and (has("PaperCurse"))) or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery"))
 	end
 
 function sewerwestground()
-	return (has("ContactLens") and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery"))
 	end
 
 function ttyd()


### PR DESCRIPTION
- Adjusted access requirements for 'Rogueport Westside - Train Ticket' and 'Keelhaul Key Grotto Entrance - Skull Gem' in Overworld.json to match APWorld logic.
- Updated logic in logic.lua to allow 'west_open' as an alternative to 'ContactLens' for sewer access.
- Bumped package version to 1.0.5 in manifest.json.