### PR TITLE
Fix tracker logic in various locations

### DIFF
--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1670,7 +1670,7 @@
                         "name": "Rogueport Sewers Star Piece in House",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "visibility_rules": [""],
+                        "visibility_rules": ["piecesanity_no_panel"],
                         "access_rules": ["PlaneCurse,UltraBoots"],
                         "item_count": 1
                     },

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -428,7 +428,7 @@
                 "name": "Amazy Dayzee",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Amazy Dayzee.png","chest_opened_img": "/images/tattles/Amazy Dayzee_Dim.png",
                 "visibility_rules":["YesPit","Ch4"],
-                "access_rules":["$pit,[$stars|5],YesPit"],
+                "access_rules":["$pit,[$stars|5],YesPit","$twilight_town,$tube,Flurrie"],
                 "map_locations": [{"map": "Tattle Log", "x": 294, "y": 1940}]
             },
             {

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -35,11 +35,11 @@ function pit()
 	end
 
 function sewerwest()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery")) or (has("UltraBoots") and ((HRGlvl1()) or (has("UltraHammer"))) and yoshi())
 	end
 
 function sewerwestground()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery")) or (HRGlvl1())
 	end
 
 function ttyd()
@@ -116,4 +116,5 @@ function HRGlvl1()
 
 function HRGlvl2()
 	return (has("SuperBoots") and has("GlitchedLogic"))
+
 	end


### PR DESCRIPTION
Add HRG to the possible conditions for sewer west ground, and add (HRG or ultra hammer) + ultra boots + yoshi as possible condition for sewer west. Fix Amazy Dayzee logic so that its tattle shows in logic in chapter 4 at the same time as the Crazee Dayzee. Fix visibility rules for Rogueport Sewers Star Piece in House so it does not show as a check when piecesanity is off. These are errors I have noticed while playing through the randomizer.