### PR TITLE
Fix tracker logic in various locations

### DIFF
--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1788,7 +1788,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1803,7 +1803,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 2",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
@@ -1811,7 +1811,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 3",
                         "chest_unopened_img": "/images/items/StarPiecePanel.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest,SuperBoots","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest,SuperBoots","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_full"],
                         "item_count": 1
                     },
@@ -1819,7 +1819,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 4",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     }
@@ -1845,7 +1845,7 @@
                 "chest_opened_img": "/images/items/CoinDim.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"
+                    "$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -485,7 +485,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["YesPit"],
                 "access_rules": [
-                    "$pit"
+                    "$pit","[$pit],$HRGlvl1,Flurrie"
                 ],
                 "sections": [
                     {
@@ -1563,7 +1563,7 @@
                     {
                         "name": "Rogueport Sewers Spania Room - Defend Plus",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,Flurrie,BoatCurse,$yoshi","$sewerwestground,Flurrie,BoatCurse,UltraBoots,Koops","[$sewerwestground],Flurrie,BoatCurse,$yoshi,$HRGlvl1","[$sewerwestground],Flurrie,BoatCurse,Koops,$HRGlvl3"],
+                        "access_rules": ["$sewerwestground,Flurrie,BoatCurse,$yoshi","$sewerwestground,Flurrie,BoatCurse,UltraBoots,Koops","[$sewerwestground],Flurrie,BoatCurse,$yoshi,$HRGlvl1","[$sewerwestground],Flurrie,BoatCurse,UltraBoots,Koops,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1579,7 +1579,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie,UltraBoots","[$sewerwestground],BoatCurse,Flurrie,$HRGlvl3"],
+                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie,UltraBoots","[$sewerwestground],BoatCurse,Flurrie,UltraBoots,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1679,14 +1679,14 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$ttyd,PaperCurse,PlaneCurse","$pit,PaperCurse"],
+                        "access_rules": ["$ttyd,PaperCurse,PlaneCurse","$pit,PaperCurse","[$pit],PaperCurse,Flurrie,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
                         "name": "Rogueport Sewers Thousand Year Door - Star Piece",
                         "chest_unopened_img": "/images/items/StarPiecePanel.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$ttyd,SuperBoots"],
+                        "access_rules": ["$ttyd,SuperBoots","[$ttyd],$HRGlvl2,Flurrie"],
                         "visibility_rules": ["piecesanity_full"],
                         "item_count": 1
                     },
@@ -1694,7 +1694,7 @@
                         "name": "Rogueport Sewers Pit Entrance - Star Piece",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$pit"],
+                        "access_rules": ["$pit","[$pit],$HRGlvl1,Flurrie"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     }
@@ -1728,7 +1728,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,UltraBoots","[$sewerwestground],$HRGlvl3"],
+                        "access_rules": ["$sewerwestground,UltraBoots","[$sewerwestground],UltraBoots,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1756,14 +1756,14 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$twilight_town","[$twilight_town],$HRGlvl3"],
+                        "access_rules": ["$twilight_town","[$twilight_town],$HRG_twilight_town"],
                         "item_count": 1
                     },
                     {
                         "name": "Rogueport Sewers West Entrance - Star Piece 2",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$twilight_town","{$sewerwestground}","[$twilight_town],$HRGlvl3"],
+                        "access_rules": ["$twilight_town","{$sewerwestground}","[$twilight_town],$HRG_twilight_town"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
@@ -1780,7 +1780,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwest,UltraBoots","[$sewerwest],$HRGlvl3"],
+                        "access_rules": ["$sewerwest,UltraBoots","[$sewerwest],$HRG_sewerwest,UltraBoots"],
                         "item_count": 1
                     },
                     {
@@ -1788,7 +1788,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwest],$HRG_sewerwest"],
                         "item_count": 1
                     },
                     {
@@ -1803,7 +1803,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 2",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwest],$HRG_sewerwest"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
@@ -1811,7 +1811,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 3",
                         "chest_unopened_img": "/images/items/StarPiecePanel.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest,SuperBoots","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest,SuperBoots","[$sewerwest],$HRG_sewerwest,SuperBoots"],
                         "visibility_rules": ["piecesanity_full"],
                         "item_count": 1
                     },
@@ -1819,7 +1819,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 4",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"],
+                        "access_rules": ["$sewerwest","[$sewerwest],$HRG_sewerwest"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     }
@@ -1845,7 +1845,7 @@
                 "chest_opened_img": "/images/items/CoinDim.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$sewerwest","[$sewerwestground],$yoshi,$HRGlvl3"
+                    "$sewerwest","[$sewerwest],$HRG_sewerwest"
                 ],
                 "sections": [
                     {
@@ -2907,7 +2907,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town","[$twilight_town],$HRGlvl3"
+                    "$twilight_town","[$twilight_town],$HRG_twilight_town"
                 ],
                 "sections": [
                     {
@@ -3023,7 +3023,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town,ShopKey","[$twilight_town],$HRGlvl3,ShopKey"
+                    "$twilight_town,ShopKey","[$twilight_town],$HRG_twilight_town,ShopKey"
                 ],
                 "sections": [
                     {
@@ -3085,7 +3085,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town","[$twilight_town],$HRGlvl3"
+                    "$twilight_town","[$twilight_town],$HRG_twilight_town"
                 ],
                 "sections": [
                     {
@@ -4711,7 +4711,7 @@
                 "chest_opened_img": "/images/items/YBlockOpen.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$palace"
+                    "$palace","[$palace],HRG_palace"
                 ],
                 "sections": [
                     {
@@ -4795,7 +4795,7 @@
                 "chest_opened_img": "/images/items/YBlockOpen.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$palace,$ttyd,PalaceKey1"
+                    "$palace,PalaceKey1","[$palace],PalaceKey1,$HRG_palace"
                 ],
                 "sections": [
                     {
@@ -4932,13 +4932,13 @@
                     {
                         "name": "Goal: Defeat Shadow Queen",
                         "visibility_rules": ["defeat_shadow_queen"],
-                        "access_rules": ["$palace,$palaceright,Bobbery,$yoshi,UltraBoots,PalaceKey3,PaperCurse,Flurrie,UltraHammer,PlaneCurse","YesPalaceSkip,$palace"],
+                        "access_rules": ["$palace,$palaceright,Bobbery,$yoshi,UltraBoots,PalaceKey3,PaperCurse,Flurrie,UltraHammer,PlaneCurse","YesPalaceSkip,$palace","YesPalaceSkip,[$palace],$HRG_palace"],
                         "item_count": 1
                     },
                     {
                         "name": "Goal: Bonetail",
                         "visibility_rules": ["defeat_bonetail"],
-                        "access_rules": ["$pit,$stars|5"],
+                        "access_rules": ["$pit,$stars|5","[$pit],$stars|5,$HRGlvl1,Flurrie"],
                         "item_count": 1
                     }
 		],

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -4711,7 +4711,7 @@
                 "chest_opened_img": "/images/items/YBlockOpen.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$palace","[$palace],HRG_palace"
+                    "$palace","[$palace],$HRG_palace"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1670,7 +1670,7 @@
                         "name": "Rogueport Sewers Star Piece in House",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "visibility_rules": [""],
+                        "visibility_rules": ["piecesanity_no_panel"],
                         "access_rules": ["PlaneCurse,UltraBoots"],
                         "item_count": 1
                     },

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1563,7 +1563,7 @@
                     {
                         "name": "Rogueport Sewers Spania Room - Defend Plus",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,Flurrie,BoatCurse,$yoshi","$sewerwestground,Flurrie,BoatCurse,UltraBoots,Koops"],
+                        "access_rules": ["$sewerwestground,Flurrie,BoatCurse,$yoshi","$sewerwestground,Flurrie,BoatCurse,UltraBoots,Koops","[$sewerwestground],Flurrie,BoatCurse,$yoshi,$HRGlvl1","[$sewerwestground],Flurrie,BoatCurse,Koops,$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1571,7 +1571,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie"],
+                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie","[$sewerwestground],BoatCurse,Flurrie,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1579,7 +1579,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie,UltraBoots"],
+                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie,UltraBoots","[$sewerwestground],BoatCurse,Flurrie,$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1587,7 +1587,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie"],
+                        "access_rules": ["$sewerwestground,BoatCurse,Flurrie","[$sewerwestground],BoatCurse,Flurrie,$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1595,7 +1595,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["SuperHammer"],
+                        "access_rules": ["SuperHammer","[SuperHammer],$HRGlvl1"],
                         "item_count": 1
                     },
                     {
@@ -1728,7 +1728,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwestground,UltraBoots"],
+                        "access_rules": ["$sewerwestground,UltraBoots","[$sewerwestground],$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1756,14 +1756,14 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$twilight_town"],
+                        "access_rules": ["$twilight_town","[$twilight_town],$HRGlvl3"],
                         "item_count": 1
                     },
                     {
                         "name": "Rogueport Sewers West Entrance - Star Piece 2",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$twilight_town","{$sewerwestground}"],
+                        "access_rules": ["$twilight_town","{$sewerwestground}","[$twilight_town],$HRGlvl3"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
@@ -1780,7 +1780,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwest,UltraBoots"],
+                        "access_rules": ["$sewerwest,UltraBoots","[$sewerwest],$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1788,7 +1788,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi"],
+                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "item_count": 1
                     },
                     {
@@ -1803,7 +1803,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 2",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi"],
+                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
@@ -1811,7 +1811,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 3",
                         "chest_unopened_img": "/images/items/StarPiecePanel.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest,SuperBoots"],
+                        "access_rules": ["$sewerwest,SuperBoots","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_full"],
                         "item_count": 1
                     },
@@ -1819,7 +1819,7 @@
                         "name": "Rogueport Sewers Town - Star Piece 4",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi"],
+                        "access_rules": ["$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     }
@@ -1845,7 +1845,7 @@
                 "chest_opened_img": "/images/items/CoinDim.png",
                 "overlay_background": "#000000",
                 "access_rules": [
-                    "$sewerwest","$sewerwestground,UltraBoots,$yoshi"
+                    "$sewerwest","$sewerwestground,UltraBoots,$yoshi","[$sewerwestground],$yoshi,$HRGlvl3"
                 ],
                 "sections": [
                     {
@@ -2907,7 +2907,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town"
+                    "$twilight_town","[$twilight_town],$HRGlvl3"
                 ],
                 "sections": [
                     {
@@ -3023,7 +3023,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town,ShopKey"
+                    "$twilight_town,ShopKey","[$twilight_town],$HRGlvl3,ShopKey"
                 ],
                 "sections": [
                     {
@@ -3085,7 +3085,7 @@
                 "overlay_background": "#000000",
 		"visibility_rules": ["Ch4"],
                 "access_rules": [
-                    "$twilight_town"
+                    "$twilight_town","[$twilight_town],$HRGlvl3"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1286,34 +1286,34 @@
                         "name": "Great Tree Fake Pedestal - Star Piece",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$hundredpunis"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree 100-Puni Pedestal - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["$hundredpunis"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree 100-Puni Pedestal - Star Piece",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["$hundredpunis"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Lower Duplex - Coin",
                         "visibility_rules": [""],
-                        "access_rules": ["$hundredpunis,SuperBoots"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis,SuperBoots"],
                         "item_count": 1
                     },
                     {
                         "name": "Great Tree Pool Room - Dizzy Dial",
                         "visibility_rules": [""],
-                        "access_rules": ["$hundredpunis,Koops,SuperBoots","$hundredpunis,$yoshi,[Koops],SuperBoots"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis,Koops,SuperBoots","[$hundredpunis],$ninetypunis,$yoshi,[Koops],SuperBoots"],
                         "item_count": 1
                     },
                     {
@@ -1321,7 +1321,7 @@
                         "chest_unopened_img": "/images/items/ShineSpriteClosed.png",
                         "chest_opened_img": "/images/items/ShineSpriteOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$hundredpunis,Koops,SuperBoots","$hundredpunis,$yoshi,[Koops],SuperBoots","$hundredpunis,UltraBoots"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis,Koops,SuperBoots","[$hundredpunis],$ninetypunis,$yoshi,[Koops],SuperBoots","[$hundredpunis],$ninetypunis,UltraBoots"],
                         "item_count": 1
                     },
                     {
@@ -1329,7 +1329,7 @@
                         "chest_unopened_img": "/images/items/BigChest.png",
                         "chest_opened_img": "/images/items/BigChestOpen.png",
                         "visibility_rules": [""],
-                        "access_rules": ["$hundredpunis,Koops,SuperBoots","$hundredpunis,$yoshi,[Koops],SuperBoots"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis,Koops,SuperBoots","[$hundredpunis],$ninetypunis,$yoshi,[Koops],SuperBoots"],
                         "item_count": 1
                     },
                     {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -428,7 +428,7 @@
                 "name": "Amazy Dayzee",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Amazy Dayzee.png","chest_opened_img": "/images/tattles/Amazy Dayzee_Dim.png",
                 "visibility_rules":["YesPit","Ch4"],
-                "access_rules":["$pit,[$stars|5],YesPit"],
+                "access_rules":["$pit,[$stars|5],YesPit","$twilight_town,$tube,Flurrie"],
                 "map_locations": [{"map": "Tattle Log", "x": 294, "y": 1940}]
             },
             {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -372,7 +372,7 @@
                 "name": "Flower Fuzzy",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Flower Fuzzy.png","chest_opened_img": "/images/tattles/Flower Fuzzy_Dim.png",
                 "visibility_rules":["Ch3"],
-                "access_rules":["$westside,BlimpTicket,$yoshi","[$westside],BlimpTicket,$yoshi,$HRGlvl1","$pit,[$stars|2],YesPit","$westside,BlimpTicket,[$yoshi]","[$westside],BlimpTicket,[$yoshi],$HRGlvl1"],
+                "access_rules":["$westside,BlimpTicket,$yoshi","[$westside],BlimpTicket,$yoshi,$HRGlvl1","$keelhaul_key,[$yoshi]","[$keelhaul_key],$HRGlvl2,[$yoshi]","$pit,[$stars|2],YesPit","$westside,BlimpTicket,[$yoshi]","[$westside],BlimpTicket,[$yoshi],$HRGlvl1"],
                 "map_locations": [{"map": "Tattle Log", "x": 100, "y": 1713}]
             },
             {
@@ -421,7 +421,7 @@
                 "name": "Crazee Dayzee",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Crazee Dayzee.png","chest_opened_img": "/images/tattles/Crazee Dayzee_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town","[$twilight_town],$HRG_twilight_town"],
+                "access_rules":["$twilight_town,[Flurrie],[$tube]","[$twilight_town],$HRG_twilight_town,[Flurrie],[$tube]"],
                 "map_locations": [{"map": "Tattle Log", "x": 1251, "y": 1836}]
             },
             {
@@ -498,7 +498,7 @@
                 "name": "Boo",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Boo.png","chest_opened_img": "/images/tattles/Boo_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$steeple","$pit,[$stars|2],YesPit"],
+                "access_rules":["$steeple,[SuperHammer]","$pit,[$stars|2],YesPit"],
                 "map_locations": [{"map": "Tattle Log", "x": 1797, "y": 327}]
             },
             {
@@ -572,7 +572,7 @@
                 "name": "Hyper Cleft",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Hyper Cleft.png","chest_opened_img": "/images/tattles/Hyper Cleft_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town,$tube,Flurrie","$pit,[$stars|2],YesPit"],
+                "access_rules":["[$steeple],$twilight_town,$tube,Flurrie","$pit,[$stars|2],YesPit"],
                 "map_locations": [{"map": "Tattle Log", "x": 3030, "y": 558}]
             },
             {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -29,21 +29,21 @@
                 "name": "Hyper Goomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Hyper Goomba.png","chest_opened_img": "/images/tattles/Hyper Goomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRG_twilight_town"],
                 "map_locations": [{"map": "Tattle Log", "x": 1251, "y": 75}]
             },
             {
                 "name": "Hyper Paragoomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/H. Paragoomba.png","chest_opened_img": "/images/tattles/H. Paragoomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRG_twilight_town"],
                 "map_locations": [{"map": "Tattle Log", "x": 100, "y": 204}]
             },
             {
                 "name": "Hyper Spiky Goomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/H. S. Goomba.png","chest_opened_img": "/images/tattles/H. S. Goomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRG_twilight_town"],
                 "map_locations": [{"map": "Tattle Log", "x": 504, "y": 204}]
             },
             {
@@ -421,7 +421,7 @@
                 "name": "Crazee Dayzee",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Crazee Dayzee.png","chest_opened_img": "/images/tattles/Crazee Dayzee_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town,$tube,Flurrie"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRG_twilight_town"],
                 "map_locations": [{"map": "Tattle Log", "x": 1251, "y": 1836}]
             },
             {
@@ -572,7 +572,7 @@
                 "name": "Hyper Cleft",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Hyper Cleft.png","chest_opened_img": "/images/tattles/Hyper Cleft_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$steeple","$pit,[$stars|2],YesPit"],
+                "access_rules":["$twilight_town,$tube,Flurrie","$pit,[$stars|2],YesPit"],
                 "map_locations": [{"map": "Tattle Log", "x": 3030, "y": 558}]
             },
             {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -29,21 +29,21 @@
                 "name": "Hyper Goomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Hyper Goomba.png","chest_opened_img": "/images/tattles/Hyper Goomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
                 "map_locations": [{"map": "Tattle Log", "x": 1251, "y": 75}]
             },
             {
                 "name": "Hyper Paragoomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/H. Paragoomba.png","chest_opened_img": "/images/tattles/H. Paragoomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
                 "map_locations": [{"map": "Tattle Log", "x": 100, "y": 204}]
             },
             {
                 "name": "Hyper Spiky Goomba",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/H. S. Goomba.png","chest_opened_img": "/images/tattles/H. S. Goomba_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town"],
+                "access_rules":["$twilight_town","[$twilight_town],$HRGlvl3"],
                 "map_locations": [{"map": "Tattle Log", "x": 504, "y": 204}]
             },
             {
@@ -344,7 +344,7 @@
                 "name": "Spunia",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Spunia.png","chest_opened_img": "/images/tattles/Spunia_Dim.png",
                 "visibility_rules":[],
-                "access_rules":["$sewerwestground,BoatCurse,Flurrie","$pit,[$stars|5],YesPit"],
+                "access_rules":["$sewerwestground,BoatCurse,Flurrie","$pit,[$stars|5],YesPit","[$sewerwestground],BoatCurse,Flurrie,$HRGlvl1"],
                 "map_locations": [{"map": "Tattle Log", "x": 100, "y": 1572}]
             },
             {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -421,7 +421,7 @@
                 "name": "Crazee Dayzee",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Crazee Dayzee.png","chest_opened_img": "/images/tattles/Crazee Dayzee_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$twilight_town,[Flurrie],[$tube]","[$twilight_town],$HRG_twilight_town,[Flurrie],[$tube]"],
+                "access_rules":["$twilight_town,Flurrie,$tube"],
                 "map_locations": [{"map": "Tattle Log", "x": 1251, "y": 1836}]
             },
             {
@@ -498,7 +498,7 @@
                 "name": "Boo",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Boo.png","chest_opened_img": "/images/tattles/Boo_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$steeple,[SuperHammer]","$pit,[$stars|2],YesPit"],
+                "access_rules":["$steeple,SuperHammer","$pit,[$stars|2],YesPit"],
                 "map_locations": [{"map": "Tattle Log", "x": 1797, "y": 327}]
             },
             {

--- a/locations/Tattle_Log.json
+++ b/locations/Tattle_Log.json
@@ -498,14 +498,14 @@
                 "name": "Boo",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Boo.png","chest_opened_img": "/images/tattles/Boo_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$steeple,Vivian","$pit,[$stars|2],YesPit"],
+                "access_rules":["$steeple","$pit,[$stars|2],YesPit"],
                 "map_locations": [{"map": "Tattle Log", "x": 1797, "y": 327}]
             },
             {
                 "name": "Atomic Boo",
                 "sections": [{}], "chest_unopened_img": "/images/tattles/Atomic Boo.png","chest_opened_img": "/images/tattles/Atomic Boo_Dim.png",
                 "visibility_rules":["Ch4"],
-                "access_rules":["$steeple,Vivian,SuperHammer"],
+                "access_rules":["$steeple,SuperHammer"],
                 "map_locations": [{"map": "Tattle Log", "x": 2196, "y": 327}]
             },
             {

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -35,11 +35,11 @@ function pit()
 	end
 
 function sewerwest()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery")) or (has("UltraBoots") and ((HRGlvl1()) or (has("UltraHammer"))) and yoshi())
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery")) or ((has("UltraBoots")) and (has("UltraHammer")) and (yoshi()))
 	end
 
 function sewerwestground()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery")) or (HRGlvl1())
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery"))
 	end
 
 function ttyd()
@@ -116,5 +116,9 @@ function HRGlvl1()
 
 function HRGlvl2()
 	return (has("SuperBoots") and has("GlitchedLogic"))
-
 	end
+
+function HRGlvl3()
+	return (has("UltraBoots") and has("GlitchedLogic"))
+	end
+

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -126,4 +126,9 @@ function HRG_sewerwest()
 	return ((has("PaperCurse") or (has("UltraBoots") and yoshi())) and has("GlitchedLogic"))
 	end
 
+function HRG_palace()
+	return (has("Flurrie") and has("GlitchedLogic")) and (((stars(0)) and has("Chapter0")) or ((stars(1)) and has("Chapter1")) or ((stars(2)) and has("Chapter2")) or ((stars(3)) and has("Chapter3")) or ((stars(4)) and has("Chapter4")) or ((stars(5)) and has("Chapter5")) or ((stars(6)) and has("Chapter6")) or ((stars(7)) and has("Chapter7")))
+	end
+
+
 

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -106,6 +106,10 @@ function tenpunis()
 	return has("PuniOrb") and (has("RedKey") or has("BlueKey"))
 	end
 
+function ninetypunis()
+	return has("PuniOrb") and has("BlueKey")
+	end
+
 function hundredpunis()
 	return has("PuniOrb") and has("RedKey") and has("BlueKey")
 	end
@@ -129,6 +133,7 @@ function HRG_sewerwest()
 function HRG_palace()
 	return (has("Flurrie") and has("GlitchedLogic")) and (((stars(0)) and has("Chapter0")) or ((stars(1)) and has("Chapter1")) or ((stars(2)) and has("Chapter2")) or ((stars(3)) and has("Chapter3")) or ((stars(4)) and has("Chapter4")) or ((stars(5)) and has("Chapter5")) or ((stars(6)) and has("Chapter6")) or ((stars(7)) and has("Chapter7")))
 	end
+
 
 
 

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -35,11 +35,11 @@ function pit()
 	end
 
 function sewerwest()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or (has("UltraHammer") and has("PaperCurse")) or (tube()) or (has("Bobbery")) or (has("UltraBoots") and ((HRGlvl1()) or (has("UltraHammer"))) and yoshi())
 	end
 
 function sewerwestground()
-	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery"))
+	return ((has("ContactLens") or has("west_open")) and has("PaperCurse")) or has("UltraHammer") or (tube()) or (has("Bobbery")) or (HRGlvl1())
 	end
 
 function ttyd()
@@ -116,4 +116,5 @@ function HRGlvl1()
 
 function HRGlvl2()
 	return (has("SuperBoots") and has("GlitchedLogic"))
+
 	end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -118,7 +118,12 @@ function HRGlvl2()
 	return (has("SuperBoots") and has("GlitchedLogic"))
 	end
 
-function HRGlvl3()
-	return (has("UltraBoots") and has("GlitchedLogic"))
+function HRG_twilight_town()
+	return ((has("UltraBoots") or (has("PaperCurse") and yoshi())) and has("GlitchedLogic"))
 	end
+
+function HRG_sewerwest()
+	return ((has("PaperCurse") or (has("UltraBoots") and yoshi())) and has("GlitchedLogic"))
+	end
+
 


### PR DESCRIPTION
Add ultra hammer + ultra boots + yoshi as a possible condition for sewer west. Fix Amazy Dayzee logic so that its tattle shows in logic in chapter 4 at the same time as the Crazee Dayzee. Fix visibility rules for Rogueport Sewers Star Piece in House so it does not show as a check when piecesanity is off. Add a 3rd level of HRG logic, and make more checks show up as yellow when using HRG (Spania Room with flurrie and boat mode, sewer west with ultra boots + yoshi, twilight town with ultra boots). These are errors I have noticed while playing through the randomizer.

This PR corrects the stupid mistake I made last time of making the additional HRG checks green.