### PR TITLE
Fix Logic for Pit & HRG Chs 2&5

### DIFF
--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -491,61 +491,61 @@
                     {
                         "name": "Pit of 100 Trials Floor 10 - Sleepy Stomp",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|1]"],
+                        "access_rules": ["[$chapters|1]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 20 - Fire Drive",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|1]"],
+                        "access_rules": ["[$chapters|1]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 30 - Zap Tap",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|2]"],
+                        "access_rules": ["[$chapters|2]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 40 - Pity Flower",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|2]"],
+                        "access_rules": ["[$chapters|2]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 50 - Strange Sack",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|3]"],
+                        "access_rules": ["[$chapters|3]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 60 - Double Dip",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|3]"],
+                        "access_rules": ["[$chapters|3]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 70 - Double Dip P",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|4]"],
+                        "access_rules": ["[$chapters|4]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 80 - Bump Attack",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|4]"],
+                        "access_rules": ["[$chapters|4]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 90 - Lucky Day",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|5]"],
+                        "access_rules": ["[$chapters|5]"],
                         "item_count": 1
                     },
                     {
                         "name": "Pit of 100 Trials Floor 100 - Return Postage",
                         "visibility_rules": [""],
-                        "access_rules": ["[$stars|5]"],
+                        "access_rules": ["[$chapters|5]"],
                         "item_count": 1
                     }
                 ],
@@ -1286,7 +1286,7 @@
                         "name": "Great Tree Fake Pedestal - Star Piece",
                         "chest_unopened_img": "/images/items/StarPieceClosed.png",
                         "chest_opened_img": "/images/items/StarPieceOpen.png",
-                        "access_rules": ["[$hundredpunis],$ninetypunis"],
+                        "access_rules": ["[$hundredpunis],$ninetypunis,PaperCurse"],
                         "visibility_rules": ["piecesanity_no_panel"],
                         "item_count": 1
                     },

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1389,7 +1389,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch2"],
                 "access_rules": [
-                    "Flurrie,$bogglywoods,$tenpunis"
+                    "Flurrie,$bogglywoods,$tenpunis","Flurrie,[$bogglywoods],$HRGlvl2,$tenpunis"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -1151,7 +1151,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch2"],
                 "access_rules": [
-                    "Flurrie,$bogglywoods"
+                    "Flurrie,$bogglywoods", "Flurrie,[$bogglywoods],$HRGlvl2"
                 ],
                 "sections": [
                     {
@@ -1451,7 +1451,7 @@
                 "overlay_background": "#000000",
                 "visibility_rules": ["Ch2"],
                 "access_rules": [
-                    "$bogglywoods,PlaneCurse"
+                    "$bogglywoods,PlaneCurse", "[$bogglywoods],$HRGlvl2,PlaneCurse"
                 ],
                 "sections": [
                     {

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -4938,7 +4938,7 @@
                     {
                         "name": "Goal: Bonetail",
                         "visibility_rules": ["defeat_bonetail"],
-                        "access_rules": ["$pit,$stars|5","[$pit],$stars|5,$HRGlvl1,Flurrie"],
+                        "access_rules": ["$pit,$chapters|5","[$pit],$chapters|5,$HRGlvl1,Flurrie"],
                         "item_count": 1
                     }
 		],

--- a/locations/Overworld.json
+++ b/locations/Overworld.json
@@ -2460,7 +2460,8 @@
                         "name": "Petalburg Eastside - Mega Rush P",
                         "visibility_rules": [""],
                         "access_rules": ["PaperCurse","{}"],
-                        "item_count": 1
+                        "item_count": 1,
+                        "inspectable_sequence_break":true
                     },
                     {
                         "name": "Petalburg Eastside - Star Piece",
@@ -3122,7 +3123,8 @@
                         "name": "Twilight Trail Fallen Tree - Shop Key",
                         "visibility_rules": [""],
                         "access_rules": ["$tube","Koops","{}"],
-                        "item_count": 1
+                        "item_count": 1,
+                        "inspectable_sequence_break":true
                     },
                     {
                         "name": "Twilight Trail Fallen Tree - Star Piece 1",
@@ -3678,7 +3680,8 @@
                         "name": "Pirate's Grotto Gate Handle Room - Gate Handle",
                         "visibility_rules": [""],
                         "access_rules": ["$yoshi,Bobbery,BoatCurse","{}"],
-                        "item_count": 1
+                        "item_count": 1,
+                        "inspectable_sequence_break":true
                     },
                     {
                         "name": "Pirate's Grotto Gate Handle Room - Shine Sprite",

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -1,8 +1,11 @@
 STARS = {"DiamondStar", "EmeraldStar", "GoldStar", "RubyStar", "SapphireStar", "GarnetStar", "CrystalStar"}
-STAR_LOCATIONS = {"@Pit of 100 Trials/Hooktail's Castle Hooktail's Room - Diamond Star", "@Pit of 100 Trials/Great Tree Entrance - Emerald Star",
-"@Pit of 100 Trials/Glitzville Arena - Gold Star", "@Pit of 100 Trials/Creepy Steeple Upper Room - Ruby Star",
-"@Pit of 100 Trials/Pirate's Grotto Cortez' Hoard - Sapphire Star", "@Pit of 100 Trials/Poshley Heights Sanctum Altar - Garnet Star",
-"@Pit of 100 Trials/X-Naut Fortress Boss Room - Crystal Star"}
+STAR_LOCATIONS = {"@Magical Map/Pit of 100 Trials/Hooktail's Castle Hooktail's Room - Diamond Star",
+"@Magical Map/Pit of 100 Trials/Great Tree Entrance - Emerald Star",
+"@Magical Map/Pit of 100 Trials/Glitzville Arena - Gold Star",
+"@Magical Map/Pit of 100 Trials/Creepy Steeple Upper Room - Ruby Star",
+"@Magical Map/Pit of 100 Trials/Pirate's Grotto Cortez' Hoard - Sapphire Star",
+"@Magical Map/Pit of 100 Trials/Poshley Heights Sanctum Altar - Garnet Star",
+"@Magical Map/Pit of 100 Trials/X-Naut Fortress Boss Room - Crystal Star"}
 
 function stars(AMOUNT)
 	AMOUNT = tonumber(AMOUNT)

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -1,4 +1,8 @@
 STARS = {"DiamondStar", "EmeraldStar", "GoldStar", "RubyStar", "SapphireStar", "GarnetStar", "CrystalStar"}
+STAR_LOCATIONS = {"@Hooktail's Castle Hooktail's Room - Diamond Star", "@Great Tree Entrance - Emerald Star",
+"@Glitzville Arena - Gold Star", "@Creepy Steeple Upper Room - Ruby Star",
+"@Pirate's Grotto Cortez' Hoard - Sapphire Star", "@Poshley Heights Sanctum Altar - Garnet Star",
+"@X-Naut Fortress Boss Room - Crystal Star"}
 
 function stars(AMOUNT)
 	AMOUNT = tonumber(AMOUNT)
@@ -6,6 +10,18 @@ function stars(AMOUNT)
 	local count = 0
 	for _, item in pairs(STARS) do
 		if has(item) then
+			count = count + 1
+		end
+	end
+return count >= req
+end
+
+function chapters(AMOUNT)
+	AMOUNT = tonumber(AMOUNT)
+	local req = AMOUNT
+	local count = 0
+	for _, location in pairs(STAR_LOCATIONS) do
+		if can_reach(location) then
 			count = count + 1
 		end
 	end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -94,7 +94,7 @@ function fahr_outpost()
 	end
 
 function pirates_grotto()
-	return has("Bobbery") and has("SkullGem") and (yoshi()) and has("SuperBoots") and keelhaul_key()
+	return has("Bobbery") and has("SkullGem") and (yoshi()) and has("SuperBoots")
 	end
 
 function poshley_heights() -- General regional access to Poshley Heights, not the Sanctum.

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -1,11 +1,11 @@
 STARS = {"DiamondStar", "EmeraldStar", "GoldStar", "RubyStar", "SapphireStar", "GarnetStar", "CrystalStar"}
-STAR_LOCATIONS = {"@Magical Map/Pit of 100 Trials/Hooktail's Castle Hooktail's Room - Diamond Star",
-"@Magical Map/Pit of 100 Trials/Great Tree Entrance - Emerald Star",
-"@Magical Map/Pit of 100 Trials/Glitzville Arena - Gold Star",
-"@Magical Map/Pit of 100 Trials/Creepy Steeple Upper Room - Ruby Star",
-"@Magical Map/Pit of 100 Trials/Pirate's Grotto Cortez' Hoard - Sapphire Star",
-"@Magical Map/Pit of 100 Trials/Poshley Heights Sanctum Altar - Garnet Star",
-"@Magical Map/Pit of 100 Trials/X-Naut Fortress Boss Room - Crystal Star"}
+STAR_LOCATIONS = {"@Magical Map/Hooktail's Castle/Hooktail's Castle Hooktail's Room - Diamond Star",
+"@Magical Map/Great Tree/Great Tree Entrance - Emerald Star",
+"@Magical Map/Glitzpit/Glitzville Arena - Gold Star",
+"@Magical Map/Creepy Steeple/Creepy Steeple Upper Room - Ruby Star",
+"@Magical Map/Pirate's Grotto/Pirate's Grotto Cortez' Hoard - Sapphire Star",
+"@Magical Map/Poshley Heights/Poshley Heights Sanctum Altar - Garnet Star",
+"@Magical Map/X-Naut Fortress/X-Naut Fortress Boss Room - Crystal Star"}
 
 function stars(AMOUNT)
 	AMOUNT = tonumber(AMOUNT)

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -1,8 +1,8 @@
 STARS = {"DiamondStar", "EmeraldStar", "GoldStar", "RubyStar", "SapphireStar", "GarnetStar", "CrystalStar"}
-STAR_LOCATIONS = {"@Hooktail's Castle Hooktail's Room - Diamond Star", "@Great Tree Entrance - Emerald Star",
-"@Glitzville Arena - Gold Star", "@Creepy Steeple Upper Room - Ruby Star",
-"@Pirate's Grotto Cortez' Hoard - Sapphire Star", "@Poshley Heights Sanctum Altar - Garnet Star",
-"@X-Naut Fortress Boss Room - Crystal Star"}
+STAR_LOCATIONS = {"Hooktail's Castle Hooktail's Room - Diamond Star", "Great Tree Entrance - Emerald Star",
+"Glitzville Arena - Gold Star", "Creepy Steeple Upper Room - Ruby Star",
+"Pirate's Grotto Cortez' Hoard - Sapphire Star", "Poshley Heights Sanctum Altar - Garnet Star",
+"X-Naut Fortress Boss Room - Crystal Star"}
 
 function stars(AMOUNT)
 	AMOUNT = tonumber(AMOUNT)

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -1,8 +1,8 @@
 STARS = {"DiamondStar", "EmeraldStar", "GoldStar", "RubyStar", "SapphireStar", "GarnetStar", "CrystalStar"}
-STAR_LOCATIONS = {"Hooktail's Castle Hooktail's Room - Diamond Star", "Great Tree Entrance - Emerald Star",
-"Glitzville Arena - Gold Star", "Creepy Steeple Upper Room - Ruby Star",
-"Pirate's Grotto Cortez' Hoard - Sapphire Star", "Poshley Heights Sanctum Altar - Garnet Star",
-"X-Naut Fortress Boss Room - Crystal Star"}
+STAR_LOCATIONS = {"@Pit of 100 Trials/Hooktail's Castle Hooktail's Room - Diamond Star", "@Pit of 100 Trials/Great Tree Entrance - Emerald Star",
+"@Pit of 100 Trials/Glitzville Arena - Gold Star", "@Pit of 100 Trials/Creepy Steeple Upper Room - Ruby Star",
+"@Pit of 100 Trials/Pirate's Grotto Cortez' Hoard - Sapphire Star", "@Pit of 100 Trials/Poshley Heights Sanctum Altar - Garnet Star",
+"@Pit of 100 Trials/X-Naut Fortress Boss Room - Crystal Star"}
 
 function stars(AMOUNT)
 	AMOUNT = tonumber(AMOUNT)

--- a/scripts/utils.lua
+++ b/scripts/utils.lua
@@ -8,6 +8,15 @@ function has(item, amount)
 	end
 end
 
+function can_reach(location_code)
+    local location = Tracker:FindObjectForCode(location_code)
+    if location then
+        return location.AccessibilityLevel >= AccessibilityLevel.Normal
+    else
+        return false
+    end
+end
+
 function toggle_item(code)
     local active = Tracker:FindObjectForCode(code).Active
     code = code


### PR DESCRIPTION
Fixes the pit logic to refer to the number of accessible star locations rather than the number of obtained stars. The new logic matches generation logic for the APWorld.

Fixes various HRG logic in chapter 2 to be more accurate.

Allows Pirate's Grotto to show out-of-logic when using HRG.